### PR TITLE
Return valid entity data in testingtool to prevent crash

### DIFF
--- a/sp/src/tools/testtool/testingtool.h
+++ b/sp/src/tools/testtool/testingtool.h
@@ -59,7 +59,7 @@ public:
 	virtual void	ServerPreSetupVisibility() {}
 
 	// Used to allow the tool to spawn different entities when it's active
-	virtual const char *GetEntityData( const char *pActualEntityData ) { return ""; }
+	virtual const char *GetEntityData( const char *pActualEntityData ) { return pActualEntityData; }
 
 	// Client calls:
 			// Level init, shutdown


### PR DESCRIPTION
In `testingtool.h`, `GetEntityData` requires valid entity data to be returned.

Originally, `""` is returned:
https://github.com/ashifolfi/source-sdk-2013/blob/f815945844a68dd7d119a01bff9d526614c30edb/sp/src/tools/testtool/testingtool.h#L62

When you load a map for the first time, the tool loads successfully and there are no issues.

However, on a new map change (e.g. typing the command `map dm_lockdown`), a crash will occur that could be identified with the following pop-up while debugging:
```
---------------- Assert ----------------
File: e:\directorscutagain\mp\src\game\server\ai_activity.cpp
Line: 72
Assert: Assertion Failed: m_pActivitySR
```
This is fixed by returning the `pActualEntityData` argument, which contains the map's entities:
```cpp
virtual const char *GetEntityData( const char *pActualEntityData ) { return pActualEntityData; }
```
